### PR TITLE
fix: bump min supported version due to types unsupported on current

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ module "cgw" {
 
 | Name | Version |
 |------|---------|
-| terraform | >= 0.12.6 |
+| terraform | >= 0.12.26 |
 | aws | >= 2.23 |
 
 ## Providers

--- a/examples/complete/README.md
+++ b/examples/complete/README.md
@@ -19,7 +19,7 @@ Note that this example may create resources which cost money. Run `terraform des
 
 | Name | Version |
 |------|---------|
-| terraform | >= 0.12.6 |
+| terraform | >= 0.12.26 |
 | aws | >= 2.23 |
 
 ## Providers

--- a/examples/complete/versions.tf
+++ b/examples/complete/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 0.12.6"
+  required_version = ">= 0.12.26"
 
   required_providers {
     aws = ">= 2.23"

--- a/versions.tf
+++ b/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 0.12.6"
+  required_version = ">= 0.12.26"
 
   required_providers {
     aws = ">= 2.23"


### PR DESCRIPTION
## Description
- bump min supported version due to types unsupported on current

## Motivation and Context
- get static checks back to passing state

## Breaking Changes
- no

## How Has This Been Tested?
- ci-cd static checks