### PR TITLE
feat: Add device_name as optional param

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ module "cgw" {
     IP2 = {
       bgp_asn    = 65112
       ip_address = "85.38.42.93"
+      device_name = "something"
     }
   }
 

--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -15,6 +15,7 @@ module "cgw" {
     IP2 = {
       bgp_asn    = 65112
       ip_address = "85.38.42.93"
+      device_name = "something"
     }
   }
 

--- a/main.tf
+++ b/main.tf
@@ -3,6 +3,7 @@ resource "aws_customer_gateway" "this" {
 
   bgp_asn    = each.value["bgp_asn"]
   ip_address = each.value["ip_address"]
+  device_name = lookup(each.value, "device_name", null)
   type       = "ipsec.1"
 
   tags = merge(


### PR DESCRIPTION
Add device_name as optional param in customer_gateways object.
This is not a mandatory parameter and doesn't break any existing functionality

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->  
aws_customer_gateway resource has the optional feature to specify device_name which is not present in module
<!--- If it fixes an open issue, please link to the issue here. -->

## Breaking Changes
<!-- Does this break backwards compatibility with the current major version? --> No
<!-- If so, please provide an explanation why it is necessary. -->

## How Has This Been Tested?
- [x] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [x] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes --> Applies to my infra
- [x] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
