### PR TITLE
feat: Adjust optional params for the aws_customer_gateway, add device_name and certificate_arn

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,13 +55,13 @@ module "cgw" {
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 4.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 4.40 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 4.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 4.40 |
 
 ## Modules
 

--- a/examples/complete/README.md
+++ b/examples/complete/README.md
@@ -20,7 +20,7 @@ Note that this example may create resources which cost money. Run `terraform des
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 4.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 4.40 |
 
 ## Providers
 

--- a/examples/complete/versions.tf
+++ b/examples/complete/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 4.0"
+      version = ">= 4.40"
     }
   }
 }

--- a/main.tf
+++ b/main.tf
@@ -1,9 +1,10 @@
 resource "aws_customer_gateway" "this" {
   for_each = var.create ? var.customer_gateways : {}
 
-  bgp_asn    = each.value["bgp_asn"]
-  ip_address = each.value["ip_address"]
-  type       = "ipsec.1"
+  bgp_asn     = each.value["bgp_asn"]
+  ip_address  = each.value["ip_address"]
+  device_name = try(each.value["device_name"], null)
+  type        = "ipsec.1"
 
   tags = merge(
     {

--- a/main.tf
+++ b/main.tf
@@ -1,10 +1,11 @@
 resource "aws_customer_gateway" "this" {
   for_each = var.create ? var.customer_gateways : {}
 
-  bgp_asn     = each.value["bgp_asn"]
-  ip_address  = each.value["ip_address"]
-  device_name = try(each.value["device_name"], null)
-  type        = "ipsec.1"
+  bgp_asn         = try(each.value["bgp_asn"], null)
+  certificate_arn = try(each.value["certificate_arn"], null)
+  ip_address      = try(each.value["ip_address"], null)
+  device_name     = try(each.value["device_name"], null)
+  type            = "ipsec.1"
 
   tags = merge(
     {

--- a/variables.tf
+++ b/variables.tf
@@ -14,15 +14,6 @@ variable "customer_gateways" {
   description = "Maps of Customer Gateway's attributes (BGP ASN and Gateway's Internet-routable external IP address)"
   type        = map(map(any))
   default     = {}
-
-  validation {
-    condition = alltrue([
-      for gateway in var.customer_gateways : (
-        can(gateway.ip_address) || can(gateway.certificate_arn)
-      )
-    ])
-    error_message = "Each customer gateway entry must contain either 'ip_address' or 'certificate_arn'."
-  }
 }
 
 variable "tags" {

--- a/variables.tf
+++ b/variables.tf
@@ -14,6 +14,15 @@ variable "customer_gateways" {
   description = "Maps of Customer Gateway's attributes (BGP ASN and Gateway's Internet-routable external IP address)"
   type        = map(map(any))
   default     = {}
+
+  validation {
+    condition = alltrue([
+      for gateway in var.customer_gateways : (
+        can(gateway.ip_address) || can(gateway.certificate_arn)
+      )
+    ])
+    error_message = "Each customer gateway entry must contain either 'ip_address' or 'certificate_arn'."
+  }
 }
 
 variable "tags" {

--- a/versions.tf
+++ b/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 4.0"
+      version = ">= 4.40"
     }
   }
 }


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

Adding optional param device_name to the cgw

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

I've got few existing VPN tunnels I'd like to move under tf management, and some cgws have that device_name set, but module doesn't allow to set it. Missing device_name results in cgw recreation. 

## Breaking Changes
<!-- Does this break backwards compatibility with the current major version? -->
<!-- If so, please provide an explanation why it is necessary. -->

n/a 

## How Has This Been Tested?
- [ ] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [x] I have tested and validated these changes using one or more of the provided `examples/*` projects
- [x] I have executed `pre-commit run -a` on my pull request
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->

Trivial change, so just tested in my env this solves the problem.